### PR TITLE
Fix preference methods returning all the preferences

### DIFF
--- a/src/ampache.py
+++ b/src/ampache.py
@@ -2769,12 +2769,12 @@ class API(object):
             * filter_str  = (string) search the name of a preference //optional
         """
         ampache_url = self.AMPACHE_URL + '/server/' + self.AMPACHE_API + '.server.php'
-        data = {'action': 'user_preferences',
+        data = {'action': 'user_preference',
                 'auth': self.AMPACHE_SESSION,
                 'filter': filter_str}
         data = urllib.parse.urlencode(data)
         full_url = ampache_url + '?' + data
-        ampache_response = self.fetch_url(full_url, self.AMPACHE_API, 'user_preferences')
+        ampache_response = self.fetch_url(full_url, self.AMPACHE_API, 'user_preference')
         if not ampache_response:
             return False
         return self.return_data(ampache_response)
@@ -2807,12 +2807,12 @@ class API(object):
             * filter_str  = (string) search the name of a preference //optional
         """
         ampache_url = self.AMPACHE_URL + '/server/' + self.AMPACHE_API + '.server.php'
-        data = {'action': 'system_preferences',
+        data = {'action': 'system_preference',
                 'auth': self.AMPACHE_SESSION,
                 'filter': filter_str}
         data = urllib.parse.urlencode(data)
         full_url = ampache_url + '?' + data
-        ampache_response = self.fetch_url(full_url, self.AMPACHE_API, 'system_preferences')
+        ampache_response = self.fetch_url(full_url, self.AMPACHE_API, 'system_preference')
         if not ampache_response:
             return False
         return self.return_data(ampache_response)

--- a/src/ampache.py
+++ b/src/ampache.py
@@ -2766,7 +2766,7 @@ class API(object):
             Returns preference based on the specified filter_str
 
             INPUTS
-            * filter_str  = (string) search the name of a preference //optional
+            * filter_str  = (string) search the name of a preference
         """
         ampache_url = self.AMPACHE_URL + '/server/' + self.AMPACHE_API + '.server.php'
         data = {'action': 'user_preference',
@@ -2804,7 +2804,7 @@ class API(object):
             Returns preference based on the specified filter_str
 
             INPUTS
-            * filter_str  = (string) search the name of a preference //optional
+            * filter_str  = (string) search the name of a preference
         """
         ampache_url = self.AMPACHE_URL + '/server/' + self.AMPACHE_API + '.server.php'
         data = {'action': 'system_preference',


### PR DESCRIPTION
Fix what appears to be a copy-paste error:

Calling the method `user_preference` was returning all the user preferences by invoking the action `user_preferences` instead of invoking the action matching the method name and returning only the requested preference.

Similarly, the method `system_preference` was invoking the action `system_preferences`.